### PR TITLE
Update section on image data types.

### DIFF
--- a/tutorial/01_images_are_arrays.md
+++ b/tutorial/01_images_are_arrays.md
@@ -99,7 +99,7 @@ See [Coordinate conventions](https://scikit-image.org/docs/stable/user_guide/num
 
 ## Data types and image values
 
-In literature, one finds different conventions for representing image values:
+There are different conventions for representing image intensity values, the most common ones being:
 
 ```
   0 - 255   where  0 is black, 255 is white
@@ -107,7 +107,7 @@ In literature, one finds different conventions for representing image values:
 ```
 
 ``scikit-image`` supports both conventions—the choice is determined by the
-data type of the array.
+data type (`dtype`) of the array.
 
 E.g., here, we generate two equally valid images:
 
@@ -123,11 +123,11 @@ ax0.imshow(linear0, cmap='gray')
 ax1.imshow(linear1, cmap='gray');
 ```
 
-When we first designed the library, we always *assumed* that floating type images go from 0-1, and unsigned bytes from 0 to 255.
+When we first designed the library, we *assumed* that floating-point type images would always range from 0 to 1, and unsigned integers from 0 to 255.
 
-For floating point images, we're moving away from that design, because often you want to represent quantities that don't fit that mold: e.g., you may be looking at temperature or rainfall data.
+We are moving away from that design, because often you will find quantities that don't fit that mold (temperature or rainfall data, fluorescence microscopy images, ...).
 
-If you're just working with standard imaging data, continue to use 0-1.
+If you're working with standard imaging data, continue to use 0-1.
 
 When loading integer images (e.g., 0-255), you'll often want to convert those to floating point (0-1). You may do that using `img_as_float`:
 

--- a/tutorial/01_images_are_arrays.md
+++ b/tutorial/01_images_are_arrays.md
@@ -139,7 +139,7 @@ cat_float = ski.util.img_as_float(cat)
 print(cat_float.dtype, cat_float.min(), cat_float.max())
 
 print()
-print("231/255 =", 231/255.)
+print("cat.max()/255 =", cat.max()/255)
 ```
 
 More at https://scikit-image.org/docs/stable/user_guide/data_types.html.

--- a/tutorial/01_images_are_arrays.md
+++ b/tutorial/01_images_are_arrays.md
@@ -147,9 +147,9 @@ More at https://scikit-image.org/docs/stable/user_guide/data_types.html.
 
 ## Image I/O
 
-Mostly, we won't be using images from the scikit-image example datasets, but images stored on disk in JPEG, PNG, or TIFF format. Since scikit-image operates on NumPy arrays, *any* image reader library that returns arrays will do. We recommend `imageio`, but `matplotlib`, `pillow`, etc. also work.
+Usually, we don't use images from the scikit-image example datasets, but images stored on disk in JPEG, PNG, or TIFF format. Since scikit-image operates on NumPy arrays, *any* image reader library that returns arrays will do. We recommend `imageio`, but `matplotlib`, `pillow`, etc. also work.
 
-scikit-image provides a convenience wrapper around `image`, in the form of the `skimage.io` submodule:
+scikit-image provides a convenience wrapper around `imageio`, in the form of the `skimage.io` submodule:
 
 ```python
 image = ski.io.imread('./data/balloon.jpg')


### PR DESCRIPTION
@lagru as discussed yesterday; not only floating-point type images may have 'exotic' ranges (see this [example](https://scikit-image.org/docs/stable/auto_examples/applications/plot_3d_interaction.html): `range: (10, 4095)`). /cc @stefanv 